### PR TITLE
Fix punctuation in README description

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Full customizable generic MUI table React component
 - 100 % Typescript
 - Full customization
-- A presentational component
+- A presentational component.
 - Respect of **Open/Closed principles** with a full extensibility
     1. Add of pagination and search on demand
     2. Add of row actions on demand


### PR DESCRIPTION
Corrected punctuation in the description of the component.

## Metadata

### test_tags
- [ ] @smoke
- [x] @authentication
- [x] @core

### test_type
- [ ] all
- [ ] authentication
- [ ] dashboard
- [x] organizations
- [x] incidents

### related_pr_id
7777

<!-- related_pr_id: 7777 -->
